### PR TITLE
✨ Fix SSH key configuration in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration to enhance security and enable SSH-based operations.

* [`.github/workflows/build-and-commit.yml`](diffhunk://#diff-f6388d17ad9d1ffad649264dff553a00597a9c1a716ebeaed61d2b873ad22cc1R17-R18): Added the `ssh-key` parameter to the `actions/checkout@v4` step, using the `DEPLOY_KEY` secret for secure SSH authentication.