### PR TITLE
🔖 Add GitHub Actions workflow to update major release tag on new releases

### DIFF
--- a/.github/workflows/major-release-tag.yml
+++ b/.github/workflows/major-release-tag.yml
@@ -1,0 +1,24 @@
+name: Update Major Release Tag
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  movetag:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get major version num and update tag
+      run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -fa "${MAJOR}" -m 'Update major version tag'
+          git push origin "${MAJOR}" --force


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically update the major release tag whenever a new release is created.

### New GitHub Actions Workflow:
* [`.github/workflows/major-release-tag.yml`](diffhunk://#diff-795a65b943556d553e886118695447d90fb4b97dc6117b9c5b74d77a69ed77fbR1-R24): Added a workflow named "Update Major Release Tag" that triggers on release creation. It calculates the major version number from the release tag, updates the corresponding major version tag, and force-pushes it to the repository.