### PR TITLE
:sparkles: Add default regex list

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -16,23 +16,23 @@ jobs:
           node-version: '20'
 
       - name: Test with list
-        uses: IamPekka058/branchMatchRegex@main
+        uses: ./
         with:
           regex: |
             - 'feature/*'
             - 'test/*'
 
       - name: Test with inline list
-        uses: IamPekka058/branchMatchRegex@main
+        uses: ./
         with:
           regex: "['feature/*', 'test/*']"
 
       - name: Test with file
-        uses: IamPekka058/branchMatchRegex@main
+        uses: ./
         with:
           path: .github/workflows/branches.yml
 
       - name: Test with file
-        uses: IamPekka058/branchMatchRegex@main
+        uses: ./
         with:
           useDefaultPatterns: true

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -31,3 +31,8 @@ jobs:
         uses: IamPekka058/branchMatchRegex@main
         with:
           path: .github/workflows/branches.yml
+
+      - name: Test with file
+        uses: IamPekka058/branchMatchRegex@main
+        with:
+          useDefaultPatterns: true

--- a/DEFAULT_PATTERNS.md
+++ b/DEFAULT_PATTERNS.md
@@ -1,0 +1,20 @@
+# Default Branch Patterns
+>These default branch patterns are inspired by the Gitmoji project (https://gitmoji.dev/). Below is a description for each pattern:
+
+
+| Prefix      | Gitmoji | Description                                            | Example                       |
+|-------------|---------|--------------------------------------------------------|-------------------------------|
+| `feature/`  | ✨       | Implementing a new feature or major functionality      | `feature/user-authentication` |
+| `fix/`      | 🐛      | Fixing a bug, issue, or regression                     | `fix/crash-on-startup`        |
+| `hotfix/`   | 🚑️     | Urgent or production-critical fix                      | `hotfix/login-failure`        |
+| `docs/`     | 📝      | Documentation updates or improvements                  | `docs/api-usage-guide`        |
+| `test/`     | 🧪      | Adding or updating tests (unit, integration, etc.)     | `test/user-service-tests`     |
+| `refactor/` | ♻️      | Code refactoring without changing existing behavior    | `refactor/database-layer`     |
+| `style/`    | 🎨      | UI/UX improvements or code formatting                  | `style/button-alignment`      |
+| `ci/`       | ⚙️      | CI/CD or automation pipeline changes                   | `ci/update-pipeline`          |
+| `perf/`     | ⚡️      | Improving performance or efficiency                    | `perf/cache-optimization`     |
+| `i18n/`     | 🌍      | Localization or translation work                       | `i18n/add-french-language`    |
+| `security/` | 🔒️     | Fixing or improving security-related functionality     | `security/fix-token-leak`     |
+| `release/`  | 📦      | Preparing or managing a new release                    | `release/v2.1.0`              |
+| `chore/`    | 🛠️     | General maintenance, dependency updates, tooling, etc. | `chore/update-eslint`         |
+

--- a/README.md
+++ b/README.md
@@ -1,45 +1,66 @@
 # branchMatchRegex
 
-`branchMatchRegex` is a GitHub Action that checks if the current branch name matches a specified regex pattern. This is particularly useful for enforcing branch naming conventions in your repositories.
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/IamPekka058/branchMatchRegex)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/IamPekka058/branchMatchRegex/.github/workflows/build-and-commit.yml)
+![GitHub](https://img.shields.io/github/license/IamPekka058/branchMatchRegex)
+
+`branchMatchRegex` is  GitHub Action that checks if the current branch name matches a specified regex pattern. This is particularly useful for enforcing branch naming conventions in your repositories.
+
+> **Disclaimer**:
+> 
+> **Currently, this action can only be used in the context of a Pull Request.** It always uses the `head` branch (the source branch of the PR) for matching against the provided regex pattern(s). Support for running in other contexts and specifying a custom branch via a dedicated input is planned for a future release.
+
+> If you use `useDefaultPatterns: true`, see [DEFAULT_PATTERNS.md](./DEFAULT_PATTERNS.md) for a detailed explanation of the default branch patterns.
 
 ## Inputs
 
-### `regex`
-- **Description**: The regex pattern to match the branch name against.
-- **Required**: No
-- **Default**: `null`
+| Name               | Description                                                                 | Required | Default |
+|--------------------|-----------------------------------------------------------------------------|----------|---------|
+| `regex`            | The regex pattern to match the branch name against.                          | No       | ""      |
+| `path`             | The path to a file containing the regex pattern(s).                          | No       | ""      |
+| `useDefaultPatterns` | Use built-in default patterns if no regex or path is provided.               | No       | false    |
 
-### `path`
-- **Description**: The path to a file containing the regex pattern(s).
-- **Required**: No
-- **Default**: `null`
-
-> **Note**: Either `regex` or `path` must be provided, but not both. If both are provided, the `path` input takes precedence.
+> **Note**: Either `regex`, `path`, or `useDefaultPatterns` must be provided. If both `regex` and `path` are provided, the `path` input takes precedence.
 
 ## Example Usage
 
 Below is an example of how to use the `branchMatchRegex` action in a GitHub workflow:
 
+### Example 1: Single Regex Pattern
 ```yaml
-ame: Test branchMatchRegex Action
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Run branchMatchRegex action
-        uses: IamPekka058/branchMatchRegex@v0.1.2
-        with:
-          regex: 'feature/*'
+- name: Run branchMatchRegex action
+  uses: IamPekka058/branchMatchRegex@v0
+  with:
+    regex: 'feature/*'
 ```
 
-In this example, the action checks if the branch name matches the pattern `feature/*`.
+### Example 2: Inline list of Regex Patterns
+```yaml
+- name: Run branchMatchRegex action
+  uses: IamPekka058/branchMatchRegex@v0
+  with:
+    regex: "['feature/*', 'bugfix/*','hotfix/*']"
+```
+### Example 3: List of Regex Patterns
+```yaml
+- name: Run branchMatchRegex action
+  uses: IamPekka058/branchMatchRegex@v0
+  with:
+    regex: |
+        - 'feature/*'
+        - 'bugfix/*'
+        - 'hotfix/*'
+```
+
+### Example 4: Regex Patterns from a File
+```yaml
+- name: Run branchMatchRegex action
+  uses: IamPekka058/branchMatchRegex@v0
+  with:
+    path: './branch-regex-patterns.yml'
+```
+
+In the third example, the file `branch-regex-patterns.txt` should contain one regex pattern per line.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,15 @@ inputs:
   regex:
     description: 'The regex pattern to match the branch name against'
     required: false
-    default: null
+    default: ''
   path:
     description: 'The path to the file containing the regex pattern'
     required: false
-    default: null
+    default: ''
+  useDefaultPatterns:
+    description: 'Use default patterns for branch matching'
+    required: false
+    default: false
   
 runs:
   using: 'node20'

--- a/default-patterns.yml
+++ b/default-patterns.yml
@@ -1,0 +1,14 @@
+- feature/*
+- fix/*
+- hotfix/*
+- docs/*
+- test/*
+- refactor/*
+- style/*
+- ci/*
+- perf/*
+- i18n/*
+- security/*
+- release/*
+- chore/*
+- test/*

--- a/dist/default-patterns.yml
+++ b/dist/default-patterns.yml
@@ -1,0 +1,14 @@
+- feature/*
+- fix/*
+- hotfix/*
+- docs/*
+- test/*
+- refactor/*
+- style/*
+- ci/*
+- perf/*
+- i18n/*
+- security/*
+- release/*
+- chore/*
+- test/*

--- a/dist/index.js
+++ b/dist/index.js
@@ -40468,7 +40468,7 @@ async function run() {
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '';
+        const isPathEmpty = !regexfile || regexfile.trim() === '' || regexfile.trim() === '';
         const isRegexEmpty = !regex || regex.trim() === '';
 
         if(isPathEmpty && isRegexEmpty) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -40468,7 +40468,7 @@ async function run() {
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '' || regexfile.trim() === '';
+        const isPathEmpty = !regexfile || regexfile.trim() === '' || pathToRegexFile.trim() === '';
         const isRegexEmpty = !regex || regex.trim() === '';
 
         if(isPathEmpty && isRegexEmpty) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -40450,7 +40450,15 @@ async function run() {
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
         const regexfile = core.getInput('path', { required: false, default: "" });
+
+        const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
         const pathToRegexFile = path.resolve(regexfile);
+
+        if (useDefaultPatterns === 'true') {
+            core.info('Using standard list of regex patterns.');
+            pathToRegexFile = __nccwpck_require__.ab + "default-patterns.yml";
+        }
+
         // Check if the current branch is a pull request
         const context = github.context;
         if (!context.payload.pull_request) {
@@ -40472,7 +40480,7 @@ async function run() {
 
         const useFile = !isPathEmpty;
 
-        if (useFile && !fs.existsSync(pathToRegexFile)) {
+        if (useFile && !fs.existsSync(__nccwpck_require__.ab + "default-patterns.yml")) {
             core.setFailed(`File "${pathToRegexFile}" does not exist.`);
             return;
         }
@@ -40480,7 +40488,7 @@ async function run() {
         let regexContent = [];
         
         if (useFile) {
-            const file = fs.readFileSync(pathToRegexFile, 'utf8');
+            const file = fs.readFileSync(__nccwpck_require__.ab + "default-patterns.yml", 'utf8');
             regexContent = YAML.parse(file);
         } else {
             regexContent = YAML.parse(regex);

--- a/dist/index.js
+++ b/dist/index.js
@@ -40452,7 +40452,7 @@ async function run() {
         const regexfile = core.getInput('path', { required: false, default: "" });
 
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
-        const pathToRegexFile = path.resolve(regexfile);
+        let pathToRegexFile = path.resolve(regexfile);
 
         if (useDefaultPatterns === 'true') {
             core.info('Using standard list of regex patterns.');

--- a/dist/index.js
+++ b/dist/index.js
@@ -40449,13 +40449,14 @@ async function run() {
         //   - "regex1"
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
-        const regexfile = core.getInput('path', { required: false, default: "" });
-
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
+
+        let regexfile = core.getInput('path', { required: false, default: "" });
         let pathToRegexFile = path.resolve(regexfile);
 
         if (useDefaultPatterns === 'true') {
             core.info('Using standard list of regex patterns.');
+            regexfile = 'default-patterns.yml';
             pathToRegexFile = __nccwpck_require__.ab + "default-patterns.yml";
         }
 
@@ -40468,7 +40469,7 @@ async function run() {
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '' || pathToRegexFile.trim() === '';
+        const isPathEmpty = !regexfile || regexfile.trim() === '';
         const isRegexEmpty = !regex || regex.trim() === '';
 
         if(isPathEmpty && isRegexEmpty) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function run() {
         const regexfile = core.getInput('path', { required: false, default: "" });
 
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
-        const pathToRegexFile = path.resolve(regexfile);
+        let pathToRegexFile = path.resolve(regexfile);
 
         if (useDefaultPatterns === 'true') {
             core.info('Using standard list of regex patterns.');

--- a/index.js
+++ b/index.js
@@ -18,7 +18,15 @@ async function run() {
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
         const regexfile = core.getInput('path', { required: false, default: "" });
+
+        const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
         const pathToRegexFile = path.resolve(regexfile);
+
+        if (useDefaultPatterns === 'true') {
+            core.info('Using standard list of regex patterns.');
+            pathToRegexFile = path.resolve(__dirname, 'default-patterns.yml');
+        }
+
         // Check if the current branch is a pull request
         const context = github.context;
         if (!context.payload.pull_request) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function run() {
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '';
+        const isPathEmpty = !regexfile || regexfile.trim() === '' || regexfile.trim() === '';
         const isRegexEmpty = !regex || regex.trim() === '';
 
         if(isPathEmpty && isRegexEmpty) {

--- a/index.js
+++ b/index.js
@@ -17,13 +17,14 @@ async function run() {
         //   - "regex1"
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
-        const regexfile = core.getInput('path', { required: false, default: "" });
-
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
+
+        let regexfile = core.getInput('path', { required: false, default: "" });
         let pathToRegexFile = path.resolve(regexfile);
 
         if (useDefaultPatterns === 'true') {
             core.info('Using standard list of regex patterns.');
+            regexfile = 'default-patterns.yml';
             pathToRegexFile = path.resolve(__dirname, 'default-patterns.yml');
         }
 
@@ -36,7 +37,7 @@ async function run() {
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '' || pathToRegexFile.trim() === '';
+        const isPathEmpty = !regexfile || regexfile.trim() === '';
         const isRegexEmpty = !regex || regex.trim() === '';
 
         if(isPathEmpty && isRegexEmpty) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function run() {
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '' || regexfile.trim() === '';
+        const isPathEmpty = !regexfile || regexfile.trim() === '' || pathToRegexFile.trim() === '';
         const isRegexEmpty = !regex || regex.trim() === '';
 
         if(isPathEmpty && isRegexEmpty) {


### PR DESCRIPTION
This pull request introduces enhancements to the `branchMatchRegex` GitHub Action, including the addition of default branch patterns, support for a `useDefaultPatterns` input, and updates to documentation and workflow files. These changes aim to improve usability and provide built-in branch naming conventions.

### New Features and Enhancements:
* **Support for Default Branch Patterns**:
  - Added `useDefaultPatterns` input to enable the use of predefined branch naming patterns. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L7-R15) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R21-R29)
  - Introduced a `default-patterns.yml` file containing default branch patterns inspired by Gitmoji.

* **Updated Documentation**:
  - Created `DEFAULT_PATTERNS.md` to describe the default branch patterns and their use cases.
  - Enhanced `README.md` with badges, updated input descriptions, and added example usage for the new `useDefaultPatterns` feature.

### Workflow and Code Changes:
* **Workflow Updates**:
  - Added a new step in `.github/workflows/test-workflow.yml` to test the `useDefaultPatterns` feature.

* **Codebase Updates**:
  - Modified `index.js` to handle the `useDefaultPatterns` input and load default patterns when enabled.