### PR TITLE
:recycle: Refactor to clean code

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40495,7 +40495,7 @@ async function run() {
 }
 
 function validateInput(inputPath, regex, useDefaultPatterns) {
-    let bothFilesSpecified = inputPath && useDefaultPatterns;
+    let bothFilesSpecified = inputPath && (useDefaultPatterns === true || useDefaultPatterns === "true");
     let allInputsEmpty = !inputPath && !regex && !useDefaultPatterns;
     let bothInputAndRegexSpecified = inputPath && regex;
     
@@ -40538,7 +40538,7 @@ function validateContext() {
 }
 
 function parseYAML(useFile, filePath, regex) {
-    if (useFile) {
+    if (useFile === true || useFile === 'true') {
         const file = fs.readFileSync(filePath, 'utf8');
         return YAML.parse(file);
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ async function run() {
 }
 
 function validateInput(inputPath, regex, useDefaultPatterns) {
-    let bothFilesSpecified = inputPath && useDefaultPatterns;
+    let bothFilesSpecified = inputPath && (useDefaultPatterns === true || useDefaultPatterns === "true");
     let allInputsEmpty = !inputPath && !regex && !useDefaultPatterns;
     let bothInputAndRegexSpecified = inputPath && regex;
     
@@ -106,7 +106,7 @@ function validateContext() {
 }
 
 function parseYAML(useFile, filePath, regex) {
-    if (useFile) {
+    if (useFile === true || useFile === 'true') {
         const file = fs.readFileSync(filePath, 'utf8');
         return YAML.parse(file);
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -18,36 +18,20 @@ async function run() {
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
-
-        let regexfile = core.getInput('path', { required: false, default: "" });
-        let pathToRegexFile = path.resolve(regexfile);
-
-        if (useDefaultPatterns === 'true') {
-            core.info('Using standard list of regex patterns.');
-            regexfile = 'default-patterns.yml';
-            pathToRegexFile = path.resolve(__dirname, 'default-patterns.yml');
-        }
-
-        // Check if the current branch is a pull request
+        const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: "true" });
+        const inputPath = core.getInput('path', { required: false, default: "" });
         const context = github.context;
-        if (!context.payload.pull_request) {
-            core.setFailed('This action can only be run in the context of a pull request');
-            return;
-        }
+        
+
+        let pathToRegexFile = populateDefaultPatterns(inputPath, useDefaultPatterns);
+
+        validateContext();
 
         const branchName = context.payload.pull_request.head.ref;
 
-        const isPathEmpty = !regexfile || regexfile.trim() === '';
-        const isRegexEmpty = !regex || regex.trim() === '';
+        validateInput(inputPath, regex, useDefaultPatterns);
 
-        if(isPathEmpty && isRegexEmpty) {
-            core.setFailed('Either path or regex must be provided');
-            return;
-        } else if(!isPathEmpty && !isRegexEmpty) {
-            core.info('Only one of path or regex must be provided. Using path.');
-        }
-
-        const useFile = !isPathEmpty;
+        const useFile = pathToRegexFile && pathToRegexFile.strip !== '';
 
         if (useFile && !fs.existsSync(pathToRegexFile)) {
             core.setFailed(`File "${pathToRegexFile}" does not exist.`);
@@ -56,12 +40,8 @@ async function run() {
         
         let regexContent = [];
         
-        if (useFile) {
-            const file = fs.readFileSync(pathToRegexFile, 'utf8');
-            regexContent = YAML.parse(file);
-        } else {
-            regexContent = YAML.parse(regex);
-        }
+        regexContent = parseYAML(useFile, pathToRegexFile, regex);
+        
         if (!Array.isArray(regexContent)) {
             regexContent = [regexContent];
         }
@@ -75,9 +55,62 @@ async function run() {
             }
         }
 
-        core.setFailed(`Branch name "${branchName}" does not match any of the provided regex patterns.`);
+        unmatchedRegex(branchName, failOnUnmatchedRegex);
+
     } catch (error) {
         core.setFailed(error.message);
+    }
+}
+
+function validateInput(inputPath, regex, useDefaultPatterns) {
+    let bothFilesSpecified = inputPath && useDefaultPatterns;
+    let allInputsEmpty = !inputPath && !regex && !useDefaultPatterns;
+    let bothInputAndRegexSpecified = inputPath && regex;
+    
+    if(bothFilesSpecified){
+        core.setFailed('Path and useDefaultPatterns cannot be used together.');
+    }
+
+    if(allInputsEmpty){ 
+        core.setFailed('Either path, regex or useDefaultPatterns must be provided.');
+    }
+
+    if(bothInputAndRegexSpecified) {
+        core.info('Only one of path or regex must be provided. Using path.');
+    }
+}
+
+function populateDefaultPatterns(inputPath, useDefaultPatterns) {
+    if(useDefaultPatterns === true){
+        return 'default-patterns.yml';
+    }
+
+    return inputPath;
+
+}
+
+function unmatchedRegex(branchName, failOnUnmatchedRegex) {
+    if (failOnUnmatchedRegex) {
+        core.setFailed(`Branch name "${branchName}" does not match any of the provided regex patterns.`);
+    } else {
+        // TODO: Comment on
+    }
+}
+
+function validateContext() {
+    const context = github.context;
+    if (!context.payload.pull_request) {
+        core.setFailed('This action can only be run in the context of a pull request');
+        return;
+    }
+}
+
+function parseYAML(useFile, filePath, regex) {
+    if (useFile) {
+        const file = fs.readFileSync(filePath, 'utf8');
+        return YAML.parse(file);
+    } else {
+        return YAML.parse(regex);
     }
 }
 


### PR DESCRIPTION
This pull request refactors the `run` function in `src/index.js` to improve code readability, modularity, and error handling. It introduces new helper functions for validation and processing, simplifies logic, and ensures better separation of concerns.

### Refactoring and modularization:
* Extracted input validation logic into a new `validateInput` function to handle checks for conflicting or missing inputs.
* Moved context validation to a separate `validateContext` function to ensure the action is run in a pull request context.
* Added a `populateDefaultPatterns` function to determine the regex file path based on the `useDefaultPatterns` flag and `inputPath`.
* Refactored YAML parsing into a new `parseYAML` function to handle both file-based and inline regex inputs.
* Introduced an `unmatchedRegex` function to handle unmatched regex scenarios, with support for a new `failOnUnmatchedRegex` flag.

### Functional improvements:
* Added a new input parameter `failOnUnmatchedRegex` to control whether the action should fail if no regex pattern matches the branch name.
* Simplified the logic for determining whether to use a regex file or inline regex by consolidating checks and removing redundant code.