### PR TITLE
:sparkles: Add branch_name and failOnUnmatchedRegex input

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -53,3 +53,9 @@ jobs:
         uses: ./
         with:
           useDefaultPatterns: true
+
+      - name: Test with file and branch name
+        uses: ./
+        with:
+          useDefaultPatterns: true
+          branchName: "feature/test"

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@
 
 ## Inputs
 
-| Name               | Description                                                                 | Required | Default |
-|--------------------|-----------------------------------------------------------------------------|----------|---------|
-| `regex`            | The regex pattern to match the branch name against.                          | No       | ""      |
-| `path`             | The path to a file containing the regex pattern(s).                          | No       | ""      |
-| `useDefaultPatterns` | Use built-in default patterns if no regex or path is provided.               | No       | false    |
+| Name                 | Description                                                      | Required | Default                |
+|----------------------|------------------------------------------------------------------|----------|------------------------|
+| `regex`              | The regex pattern to match the branch name against.              | No       | ""                    |
+| `path`               | The path to the file containing the regex pattern.               | No       | ""                    |
+| `useDefaultPatterns` | Use default patterns for branch matching.                        | No       | false                  |
+| `failOnUnmatchedRegex` | Fail the action if the branch does not match the regex pattern. | No       | true                  |
+| `branchName`         | The branch name to check against the regex pattern.              | No       | ${{ github.head_ref }} |
 
-> **Note**: Either `regex`, `path`, or `useDefaultPatterns` must be provided. If both `regex` and `path` are provided, the `path` input takes precedence.
+> **Note**: Either `regex`, `path`, or `useDefaultPatterns` must be provided. If both `regex` and `path` are provided, the `path` input takes precedence. You can't use `useDefaultPatterns` and `path` at the same time.
 
 ## Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Fail the action if the branch does not match the regex pattern'
     required: false
     default: false
-  branch:
+  branchName:
     description: 'The branch name to check against the regex pattern'
     required: false
     default: ${{ github.head_ref }}

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Use default patterns for branch matching'
     required: false
     default: false
+  branch:
+    description: 'The branch name to check against the regex pattern'
+    required: false
+    default: ${{ github.head_ref }}
   
 runs:
   using: 'node20'

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   failOnUnmatchedRegex:
     description: 'Fail the action if the branch does not match the regex pattern'
     required: false
-    default: false
+    default: true
   branchName:
     description: 'The branch name to check against the regex pattern'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Use default patterns for branch matching'
     required: false
     default: false
+  failOnUnmatchedRegex:
+    description: 'Fail the action if the branch does not match the regex pattern'
+    required: false
+    default: false
   branch:
     description: 'The branch name to check against the regex pattern'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -40512,7 +40512,7 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
 }
 
 function populateDefaultPatterns(inputPath, useDefaultPatterns) {
-    if(useDefaultPatterns === true){
+    if(useDefaultPatterns === true || useDefaultPatterns === 'true') {
         return 'default-patterns.yml';
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -40512,10 +40512,10 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
 }
 
 function populateDefaultPatterns(inputPath, useDefaultPatterns) {
-    if(useDefaultPatterns === true || useDefaultPatterns === 'true') {
+    if (useDefaultPatterns === true || useDefaultPatterns === 'true') {
         return __nccwpck_require__.ab + "default-patterns.yml";
     }
-    return path.join(__dirname, inputPath);
+    return inputPath;
 }
 
 function unmatchedRegex(branchName, failOnUnmatchedRegex) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -40513,11 +40513,9 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
 
 function populateDefaultPatterns(inputPath, useDefaultPatterns) {
     if(useDefaultPatterns === true || useDefaultPatterns === 'true') {
-        return 'default-patterns.yml';
+        return __nccwpck_require__.ab + "default-patterns.yml";
     }
-
-    return inputPath;
-
+    return path.join(__dirname, inputPath);
 }
 
 function unmatchedRegex(branchName, failOnUnmatchedRegex) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -40454,7 +40454,6 @@ async function run() {
         const inputPath = core.getInput('path', { required: false, default: "" });
         const branchName = core.getInput('branchName', { required: false, default: github.head_ref  });
         
-
         let pathToRegexFile = populateDefaultPatterns(inputPath, useDefaultPatterns);
 
         validateContext();

--- a/dist/index.js
+++ b/dist/index.js
@@ -40452,6 +40452,7 @@ async function run() {
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
         const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: "true" });
         const inputPath = core.getInput('path', { required: false, default: "" });
+        const branchName = core.getInput('branchName', { required: false, default: github.head_ref  });
         const context = github.context;
         
 
@@ -40459,10 +40460,8 @@ async function run() {
 
         validateContext();
 
-        const branchName = context.payload.pull_request.head.ref;
-
         validateInput(inputPath, regex, useDefaultPatterns);
-
+        
         const useFile = pathToRegexFile && pathToRegexFile.strip !== '';
 
         if (useFile && !fs.existsSync(pathToRegexFile)) {
@@ -40501,10 +40500,12 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
     
     if(bothFilesSpecified){
         core.setFailed('Path and useDefaultPatterns cannot be used together.');
+        return;
     }
 
     if(allInputsEmpty){ 
         core.setFailed('Either path, regex or useDefaultPatterns must be provided.');
+        return;
     }
 
     if(bothInputAndRegexSpecified) {
@@ -40524,15 +40525,18 @@ function populateDefaultPatterns(inputPath, useDefaultPatterns) {
 function unmatchedRegex(branchName, failOnUnmatchedRegex) {
     if (failOnUnmatchedRegex) {
         core.setFailed(`Branch name "${branchName}" does not match any of the provided regex patterns.`);
+        return;
     } else {
         // TODO: Comment on
     }
 }
 
-function validateContext() {
+function validateContext(branchName) {
     const context = github.context;
-    if (!context.payload.pull_request) {
-        core.setFailed('This action can only be run in the context of a pull request');
+    let branchNameUndefined = branchName === undefined || branchName === null || branchName.strip() === '';
+    
+    if (branchNameUndefined && !context.payload.pull_request) {
+        core.setFailed('If branchName is not provided, the action must be run in a pull request context.');
         return;
     }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -40449,11 +40449,10 @@ async function run() {
         //   - "regex1"
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
-        const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
-        const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: "true" });
+        const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: false });
+        const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: true });
         const inputPath = core.getInput('path', { required: false, default: "" });
         const branchName = core.getInput('branchName', { required: false, default: github.head_ref  });
-        const context = github.context;
         
 
         let pathToRegexFile = populateDefaultPatterns(inputPath, useDefaultPatterns);
@@ -40461,7 +40460,7 @@ async function run() {
         validateContext();
 
         validateInput(inputPath, regex, useDefaultPatterns);
-        
+
         const useFile = pathToRegexFile && pathToRegexFile.strip !== '';
 
         if (useFile && !fs.existsSync(pathToRegexFile)) {

--- a/src/index.js
+++ b/src/index.js
@@ -80,10 +80,10 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
 }
 
 function populateDefaultPatterns(inputPath, useDefaultPatterns) {
-    if(useDefaultPatterns === true || useDefaultPatterns === 'true') {
+    if (useDefaultPatterns === true || useDefaultPatterns === 'true') {
         return path.join(__dirname, '../assets/default-patterns.yml');
     }
-    return path.join(__dirname, inputPath);
+    return inputPath;
 }
 
 function unmatchedRegex(branchName, failOnUnmatchedRegex) {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ async function run() {
         const inputPath = core.getInput('path', { required: false, default: "" });
         const branchName = core.getInput('branchName', { required: false, default: github.head_ref  });
         
-
         let pathToRegexFile = populateDefaultPatterns(inputPath, useDefaultPatterns);
 
         validateContext();

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
 }
 
 function populateDefaultPatterns(inputPath, useDefaultPatterns) {
-    if(useDefaultPatterns === true){
+    if(useDefaultPatterns === true || useDefaultPatterns === 'true') {
         return 'default-patterns.yml';
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,10 @@ async function run() {
         //   - "regex1"
         //   - "regex2"
         const regex = core.getInput('regex', { required: false, default: "" });
-        const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: "false" });
-        const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: "true" });
+        const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: false });
+        const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: true });
         const inputPath = core.getInput('path', { required: false, default: "" });
         const branchName = core.getInput('branchName', { required: false, default: github.head_ref  });
-        const context = github.context;
         
 
         let pathToRegexFile = populateDefaultPatterns(inputPath, useDefaultPatterns);
@@ -29,7 +28,7 @@ async function run() {
         validateContext();
 
         validateInput(inputPath, regex, useDefaultPatterns);
-        
+
         const useFile = pathToRegexFile && pathToRegexFile.strip !== '';
 
         if (useFile && !fs.existsSync(pathToRegexFile)) {

--- a/src/index.js
+++ b/src/index.js
@@ -81,11 +81,9 @@ function validateInput(inputPath, regex, useDefaultPatterns) {
 
 function populateDefaultPatterns(inputPath, useDefaultPatterns) {
     if(useDefaultPatterns === true || useDefaultPatterns === 'true') {
-        return 'default-patterns.yml';
+        return path.join(__dirname, '../assets/default-patterns.yml');
     }
-
-    return inputPath;
-
+    return path.join(__dirname, inputPath);
 }
 
 function unmatchedRegex(branchName, failOnUnmatchedRegex) {


### PR DESCRIPTION
This pull request introduces new input parameters and refines existing logic to enhance the flexibility and robustness of branch name validation in the GitHub Action. The most notable changes include adding support for specifying the branch name explicitly, improving error handling, and updating documentation to reflect these enhancements.

### New Inputs and Features:
* Added `failOnUnmatchedRegex` input to control whether the action fails if the branch name does not match the regex pattern. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R19-R26) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R95-R106)
* Added `branchName` input to allow explicitly specifying the branch name to validate, defaulting to `${{ github.head_ref }}`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R19-R26) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L20-L31)

### Logic Updates:
* Updated `validateContext` to handle cases where `branchName` is not provided, ensuring the action runs only in a pull request context.
* Improved `validateInput` to return early when invalid input combinations are detected, such as using both `path` and `useDefaultPatterns`.

### Documentation Updates:
* Updated `README.md` to include descriptions of the new inputs (`failOnUnmatchedRegex` and `branchName`) and clarify restrictions on input combinations.