### PR TITLE
:sparkles: Add wild card input

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,18 @@
 
 `branchMatchRegex` is  GitHub Action that checks if the current branch name matches a specified regex pattern. This is particularly useful for enforcing branch naming conventions in your repositories.
 
-> **Disclaimer**:
-> 
-> **Currently, this action can only be used in the context of a Pull Request.** It always uses the `head` branch (the source branch of the PR) for matching against the provided regex pattern(s). Support for running in other contexts and specifying a custom branch via a dedicated input is planned for a future release.
-
 > If you use `useDefaultPatterns: true`, see [DEFAULT_PATTERNS.md](./DEFAULT_PATTERNS.md) for a detailed explanation of the default branch patterns.
 
 ## Inputs
 
-| Name                 | Description                                                      | Required | Default                |
-|----------------------|------------------------------------------------------------------|----------|------------------------|
-| `regex`              | The regex pattern to match the branch name against.              | No       | ""                    |
-| `path`               | The path to the file containing the regex pattern.               | No       | ""                    |
-| `useDefaultPatterns` | Use default patterns for branch matching.                        | No       | false                  |
-| `failOnUnmatchedRegex` | Fail the action if the branch does not match the regex pattern. | No       | true                  |
-| `branchName`         | The branch name to check against the regex pattern.              | No       | ${{ github.head_ref }} |
+| Name                   | Description                                                                 | Required | Default                |
+|------------------------|-----------------------------------------------------------------------------|----------|------------------------|
+| `regex`                | The regex pattern to match the branch name against.                         | No       | ""                    |
+| `path`                 | The path to the file containing the regex pattern.                          | No       | ""                    |
+| `useDefaultPatterns`   | Use default patterns for branch matching.                                   | No       | false                  |
+| `failOnUnmatchedRegex` | Fail the action if the branch does not match the regex pattern.             | No       | true                   |
+| `branchName`           | The branch name to check against the regex pattern.                         | No       | ${{ github.head_ref }} |
+| `useWildcard`          | If true, treat patterns as simple wildcards (e.g. feature/*) instead of full regex. | No | false |
 
 > **Note**: Either `regex`, `path`, or `useDefaultPatterns` must be provided. If both `regex` and `path` are provided, the `path` input takes precedence. You can't use `useDefaultPatterns` and `path` at the same time.
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'The branch name to check against the regex pattern'
     required: false
     default: ${{ github.head_ref }}
+  useWildcard:
+    description: 'Use wildcard matching instead of regex'
+    required: false
+    default: false
   
 runs:
   using: 'node20'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29915,14 +29915,6 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 3314:
-/***/ ((module) => {
-
-module.exports = eval("require")("react");
-
-
-/***/ }),
-
 /***/ 2613:
 /***/ ((module) => {
 
@@ -40444,7 +40436,6 @@ const path = __nccwpck_require__(6928);
 
 const core = __nccwpck_require__(7484);
 const github = __nccwpck_require__(3228);
-const { use } = __nccwpck_require__(3314);
 
 async function run() {
     try{

--- a/dist/index.js
+++ b/dist/index.js
@@ -29915,6 +29915,14 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
+/***/ 3314:
+/***/ ((module) => {
+
+module.exports = eval("require")("react");
+
+
+/***/ }),
+
 /***/ 2613:
 /***/ ((module) => {
 
@@ -40436,6 +40444,7 @@ const path = __nccwpck_require__(6928);
 
 const core = __nccwpck_require__(7484);
 const github = __nccwpck_require__(3228);
+const { use } = __nccwpck_require__(3314);
 
 async function run() {
     try{
@@ -40452,6 +40461,7 @@ async function run() {
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: false });
         const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: true });
         const inputPath = core.getInput('path', { required: false, default: "" });
+        const useWildcard = core.getInput('useWildcard', { required: false, default: false });
         const branchName = core.getInput('branchName', { required: false, default: github.head_ref  });
         
         let pathToRegexFile = populateDefaultPatterns(inputPath, useDefaultPatterns);
@@ -40476,6 +40486,12 @@ async function run() {
         }
 
         for (const regex of regexContent) {
+
+            if (useWildcard === 'true' || useWildcard === true) {
+                core.info(`Using wildcard regex: "${regex}"`);
+                regex = wildcardToRegex(regex);
+                core.info(`Converted to regex: "${regex}"`);
+            }
             const regexPattern = new RegExp(regex);
             
             if (regexPattern.test(branchName)) {
@@ -40544,6 +40560,14 @@ function parseYAML(useFile, filePath, regex) {
     } else {
         return YAML.parse(regex);
     }
+}
+
+function wildcardToRegex(pattern) {
+    // Escape regex special chars except *
+    let regex = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+    // Replace * with .*
+    regex = regex.replace(/\*/g, '.*');
+    return `^${regex}$`;
 }
 
 run();

--- a/dist/license.txt
+++ b/dist/license.txt
@@ -265,16 +265,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-@vercel/ncc
-MIT
-Copyright 2018 ZEIT, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 before-after-hook
 Apache-2.0
                                  Apache License

--- a/dist/license.txt
+++ b/dist/license.txt
@@ -265,6 +265,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+@vercel/ncc
+MIT
+Copyright 2018 ZEIT, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 before-after-hook
 Apache-2.0
                                  Apache License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchmatchregex",
-  "version": "0.1.2",
+  "version": "0.4.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ const path = require('path');
 
 const core = require('@actions/core');
 const github = require('@actions/github');
-const { use } = require('react');
 
 async function run() {
     try{


### PR DESCRIPTION
This pull request introduces a new feature to support wildcard-based branch name matching, updates the documentation to reflect this addition, and includes a version bump for the package. Below are the key changes grouped by theme:

### New Feature: Wildcard Matching
* Added a new input parameter `useWildcard` in `action.yml` and `README.md` to enable wildcard-based branch name matching instead of regex. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R27-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R20)
* Implemented the `wildcardToRegex` function in `src/index.js` to convert wildcard patterns into equivalent regex patterns.
* Updated the branch name matching logic in `src/index.js` to check if `useWildcard` is enabled and process the patterns accordingly. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R49-R54) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R24)

### Documentation Updates
* Removed outdated disclaimer in `README.md` and added details about the new `useWildcard` option.

### Version Update
* Bumped the package version in `package.json` from `0.1.2` to `0.4.0` to reflect the addition of a new feature.

### Miscellaneous
* Added an unnecessary import of `use` from `react` in `src/index.js`, which appears to be unrelated to the changes and might need removal.