### PR TITLE
:bug: Change const to let for regex input to allow reassignment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40448,7 +40448,7 @@ async function run() {
         // regex:
         //   - "regex1"
         //   - "regex2"
-        const regex = core.getInput('regex', { required: false, default: "" });
+        let regex = core.getInput('regex', { required: false, default: "" });
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: false });
         const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: true });
         const inputPath = core.getInput('path', { required: false, default: "" });

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ async function run() {
         // regex:
         //   - "regex1"
         //   - "regex2"
-        const regex = core.getInput('regex', { required: false, default: "" });
+        let regex = core.getInput('regex', { required: false, default: "" });
         const useDefaultPatterns = core.getInput('useDefaultPatterns', { required: false, default: false });
         const failOnUnmatchedRegex = core.getInput('failOnUnmatchedRegex', { required: false, default: true });
         const inputPath = core.getInput('path', { required: false, default: "" });


### PR DESCRIPTION
This pull request includes a small change in the `src/index.js` file. The change modifies the `regex` variable declaration from `const` to `let` in the `run` function to allow reassignment if needed.