### PR TITLE
:bug: Change const to let for regex iteration to allow reassignment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40476,7 +40476,7 @@ async function run() {
             regexContent = [regexContent];
         }
 
-        for (const regex of regexContent) {
+        for (regex of regexContent) {
 
             if (useWildcard === 'true' || useWildcard === true) {
                 core.info(`Using wildcard regex: "${regex}"`);

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ async function run() {
             regexContent = [regexContent];
         }
 
-        for (const regex of regexContent) {
+        for (regex of regexContent) {
 
             if (useWildcard === 'true' || useWildcard === true) {
                 core.info(`Using wildcard regex: "${regex}"`);


### PR DESCRIPTION
This pull request includes a small change in the `src/index.js` file. The change removes the `const` declaration for the `regex` variable in the `for` loop, allowing it to use an existing variable in the outer scope.