### PR TITLE
:package: Add Renovate configuration file for dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,28 +1,28 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended"],
-    "major": {
-        "automerge": false
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "major": {
+    "automerge": false
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
     },
-    "packageRules": [
-        {
-            "matchUpdateTypes": ["patch"],
-            "automerge": true
-        },
-        {
-            "matchUpdateTypes": ["pin"],
-            "commitMessagePrefix": "📌",
-            "commitMessageAction": "Pin"
-        },
-        {
-            "matchUpdateTypes": ["rollback"],
-            "commitMessagePrefix": "⬇️",
-            "commitMessageAction": "Downgrade"
-        }
-    ],
-    "commitMessagePrefix": "⬆️",
-    "commitMessageAction": "Upgrade",
-    "labels": ["📌 Dependencies"],
-    "dependencyDashboardTitle": "📌 Dependency Dashboard",
-    "dependencyDashboardLabels": ["📌 Dependencies"]
+    {
+      "matchUpdateTypes": ["pin"],
+      "commitMessagePrefix": "📌",
+      "commitMessageAction": "Pin"
+    },
+    {
+      "matchUpdateTypes": ["rollback"],
+      "commitMessagePrefix": "⬇️",
+      "commitMessageAction": "Downgrade"
+    }
+  ],
+  "commitMessagePrefix": "⬆️",
+  "commitMessageAction": "Upgrade",
+  "labels": ["📌 Dependencies"],
+  "dependencyDashboardTitle": "📌 Dependency Dashboard",
+  "dependencyDashboardLabels": ["📌 Dependencies"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"],
+    "major": {
+        "automerge": false
+    },
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["patch"],
+            "automerge": true
+        },
+        {
+            "matchUpdateTypes": ["pin"],
+            "commitMessagePrefix": "📌",
+            "commitMessageAction": "Pin"
+        },
+        {
+            "matchUpdateTypes": ["rollback"],
+            "commitMessagePrefix": "⬇️",
+            "commitMessageAction": "Downgrade"
+        }
+    ],
+    "commitMessagePrefix": "⬆️",
+    "commitMessageAction": "Upgrade",
+    "labels": ["📌 Dependencies"],
+    "dependencyDashboardTitle": "📌 Dependency Dashboard",
+    "dependencyDashboardLabels": ["📌 Dependencies"]
+}


### PR DESCRIPTION
This pull request introduces a new Renovate configuration file to automate and manage dependency updates for the project. The configuration sets up rules for automerging patch updates, customizes commit messages for different update types, and organizes dependency tracking with labels and dashboard settings.

Dependency update automation and management:

* Added `.github/renovate.json` with recommended base settings and schema reference to standardize Renovate configuration.
* Configured patch updates to automerge, while major updates require manual review.
* Customized commit message prefixes and actions for pinning and rolling back dependencies, improving commit clarity.
* Set global commit message prefixes and actions for upgrades, and applied labels for dependency-related pull requests.
* Defined a custom dependency dashboard title and labels to improve visibility and tracking of dependency updates.