### PR TITLE
:test_tube: Update test workflow to pass with renovate branches

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -42,6 +42,7 @@ jobs:
             - release/*
             - chore/*
             - test/*
+            - renovate/*
 
       - name: Test with inline list
         uses: ./
@@ -49,7 +50,7 @@ jobs:
           patterns:
             "['feature/*', 'fix/*', 'hotfix/*', 'docs/*', 'test/*',
             'refactor/*', 'style/*', 'ci/*', 'perf/*', 'i18n/*', 'security/*',
-            'release/*', 'chore/*', 'test/*']"
+            'release/*', 'chore/*', 'test/*', 'renovate/*']"
 
       - name: Test with file
         uses: ./

--- a/assets/default-patterns.yml
+++ b/assets/default-patterns.yml
@@ -12,3 +12,4 @@
 - release/*
 - chore/*
 - test/*
+- renovate/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "branchmatchregex",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "branchmatchregex",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",


### PR DESCRIPTION
This pull request adds support for the `renovate/*` pattern to both the default patterns configuration and the workflow file. This ensures that branches or pull requests matching `renovate/*` are properly recognized and handled by the workflow.

Pattern configuration updates:
* Added `renovate/*` to the list of patterns in `assets/default-patterns.yml` to include Renovate-related branches.

Workflow improvements:
* Updated `.github/workflows/test-workflow.yml` to recognize `renovate/*` in both the trigger list and the inline patterns used for testing.