### PR TITLE
🔧 Add 'renovate/*' pattern to branches configuration

### DIFF
--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -12,3 +12,4 @@
 - release/*
 - chore/*
 - test/*
+- renovate/*


### PR DESCRIPTION
This pull request makes a minor update to the branch protection configuration. The change adds the `renovate/*` branch pattern to the list of protected branches in `.github/branches.yml`.