### PR TITLE
🔧 Add reviewer to Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   "major": {
     "automerge": false
   },
+  "reviewers": ["IamPekka058"],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
This pull request makes a small configuration change to the Renovate bot settings. It adds a designated reviewer for Renovate PRs to improve code review coverage.

* Added `"IamPekka058"` as a reviewer in `.github/renovate.json` to ensure Renovate PRs are assigned for review.