### PR TITLE
:construction_worker: Disable biome linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -60,3 +60,5 @@ jobs:
           VALIDATE_BASH_EXEC: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_BIOME_FORMAT: false


### PR DESCRIPTION
This pull request makes a small update to the linter workflow configuration by disabling two additional validation checks.

* Disabled `VALIDATE_BIOME_LINT` and `VALIDATE_BIOME_FORMAT` in the `.github/workflows/linter.yml` file.